### PR TITLE
`s21_sub` and minimal tests + fix conversion error + test for it

### DIFF
--- a/src/lib/_s21_big_decimal_to_decimal.c
+++ b/src/lib/_s21_big_decimal_to_decimal.c
@@ -106,15 +106,17 @@ int _s21_big_decimal_to_decimal(_s21_big_decimal const *big_decimal_ptr,
   reminder = _s21_big_decimal_reduce_scale(&big, &scale);
 
   // Remove trailing zeros from result but not more than `desired_scale`
-  while (scale > desired_scale && reminder == 0) {
+  for (uint8_t temp_reminder = reminder;
+       scale > desired_scale && temp_reminder == 0;) {
     _s21_big_decimal temp_big = big;
-    uint8_t temp_reminder = _s21_big_decimal_reduce_scale_once(&temp_big);
+    temp_reminder = _s21_big_decimal_reduce_scale_once(&temp_big);
     if (temp_reminder == 0) {
       scale--;
       big = temp_big;
     }
   }
 
+  // Bank rounding if required
   if (reminder > 5 || (reminder == 5 && big.bits[LOW] & 1)) {
     _s21_big_decimal one_as_big = {{1, 0, 0, 0, 0, 0, big.bits[BIG_SCALE]}};
     big = _s21_big_decimal_add(&big, &one_as_big);

--- a/src/lib/s21_sub.c
+++ b/src/lib/s21_sub.c
@@ -1,0 +1,14 @@
+#include "../s21_decimal.h"
+
+int s21_sub(s21_decimal first, s21_decimal second, s21_decimal *result_ptr) {
+  _s21_big_decimal big_first = S21_DECIMAL_NULL;
+  _s21_big_decimal big_second = S21_DECIMAL_NULL;
+  _s21_big_decimal big_result = S21_DECIMAL_NULL;
+
+  _s21_decimal_to_big_decimal(&first, &big_first);
+  _s21_decimal_to_big_decimal(&second, &big_second);
+
+  big_result = _s21_big_decimal_sub(&big_first, &big_second);
+
+  return _s21_big_decimal_to_decimal(&big_result, result_ptr);
+}

--- a/src/print_bits.c
+++ b/src/print_bits.c
@@ -6,6 +6,15 @@
 
 #include "s21_decimal.h"
 
+uint32_t git_int_bits_as_uint(int x) {
+  union convert {
+    int int_value;
+    uint32_t uint_value;
+  } convert = {.int_value = x};
+
+  return convert.uint_value;
+}
+
 void s21_mul_int(s21_decimal *input, int multiplier) {
   s21_decimal x = *input;
 
@@ -25,8 +34,9 @@ void s21_mul_int(s21_decimal *input, int multiplier) {
 
 int main() {
   // 792.28162514264337593543950335 + 10 = 802.2816251426433759354395034
-  s21_decimal x = {.bits = {0xffffffff, 0xffffffff, 0xffffffff, 0x1a0000}};
-  s21_decimal y = {.bits = {1, 0, 0, 0}};
+  s21_decimal x = {.bits = {1, 1, 1, 65536}};
+  s21_decimal y = {.bits = {1, 1, 1, 655360}};
+  // s21_decimal expect = {.bits = {0x3b9aca01, 0x3b9aca01, 0x3b9aca01, 0xa0000}};
   // s21_decimal expect = {.bits = {0xe399999a, 0xafad9ae1, 0x19a1df2e, 0x190000}};
   // s21_decimal result = S21_DECIMAL_NULL;
 
@@ -42,4 +52,6 @@ int main() {
   _s21_big_decimal result = S21_DECIMAL_NULL;
   result = _s21_big_decimal_add(&big_x, &big_y);
   print_bits(sizeof(result), &result);
+
+  printf("-2147418112 as uint = %u\n", git_int_bits_as_uint(-2147418112));
 }

--- a/src/s21_decimal.h
+++ b/src/s21_decimal.h
@@ -37,6 +37,7 @@ int s21_get_sign(s21_decimal decimal);
 int s21_is_equal(s21_decimal first, s21_decimal second);
 int s21_is_zero(s21_decimal decimal);
 int s21_negate(s21_decimal value, s21_decimal *result);
+int s21_sub(s21_decimal first, s21_decimal second, s21_decimal *result_ptr);
 
 /* -----------------------------------------------------
 --------- Internal functions and definitions -----------

--- a/src/tests/tests__s21_big_decimal_to_decimal.c
+++ b/src/tests/tests__s21_big_decimal_to_decimal.c
@@ -35,7 +35,7 @@ START_TEST(smallest_decimal_round_conversion) {
   _s21_big_decimal_to_decimal(&big, &result);
 
   ck_assert_int_eq(s21_is_equal(decimal, result), 1);
-  ck_assert_int_eq(_s21_get_scale(&decimal), 28);
+  ck_assert_int_eq(_s21_get_scale(&result), 28);
 }
 END_TEST
 
@@ -48,7 +48,20 @@ START_TEST(save_scale_if_possible) {
   _s21_big_decimal_to_decimal(&big, &result);
 
   ck_assert_int_eq(s21_is_equal(decimal, result), 1);
-  ck_assert_int_eq(_s21_get_scale(&decimal), 8);
+  ck_assert_int_eq(_s21_get_scale(&result), 8);
+}
+END_TEST
+
+START_TEST(do_not_save_scale_if_not_possible) {
+  _s21_big_decimal big = {.bits = {0x8f640000, 0x3d1536f0, 0x4050652d,
+                                   0xb0ec652d, 0x33b2e3c, 0, 0x10000}};
+  s21_decimal expect = {.bits = {0x3b9aca01, 0x3b9aca01, 0x3b9aca01, 0xa0000}};
+  s21_decimal result = S21_DECIMAL_NULL;
+
+  _s21_big_decimal_to_decimal(&big, &result);
+
+  ck_assert_int_eq(s21_is_equal(expect, result), 1);
+  ck_assert_int_eq(_s21_get_scale(&result), 10);
 }
 END_TEST
 
@@ -61,6 +74,7 @@ TCase *tcase__s21_big_decimal_to_decimal(void) {
   tcase_add_test(tc, negative_decimal_round_conversion);
   tcase_add_test(tc, smallest_decimal_round_conversion);
   tcase_add_test(tc, save_scale_if_possible);
+  tcase_add_test(tc, do_not_save_scale_if_not_possible);
 
   return tc;
 }

--- a/src/tests/tests_s21_add.c
+++ b/src/tests/tests_s21_add.c
@@ -225,6 +225,66 @@ START_TEST(adding_positive_and_negative_result_positive_null) {
 }
 END_TEST
 
+START_TEST(possible_verter_test_1) {
+  s21_decimal x = {.bits = {1, 1, 1, 65536}};
+  s21_decimal y = {.bits = {1, 1, 1, 65536}};
+  s21_decimal expect = {.bits = {2, 2, 2, 65536}};
+  s21_decimal result = S21_DECIMAL_NULL;
+  int is_equal = -999;
+  int is_error = -99;
+
+  is_error = s21_add(x, y, &result);
+
+  is_equal = _tests_add_check_bits(result, expect);
+  ck_assert_int_eq(is_equal, S21_TRUE);
+  ck_assert_int_eq(is_error, 0);
+}
+
+START_TEST(possible_verter_test_2) {
+  s21_decimal x = {.bits = {1, 1, 1, 65536}};
+  s21_decimal y = {.bits = {1, 1, 1, 655360}};
+  s21_decimal expect = {.bits = {0x3b9aca01, 0x3b9aca01, 0x3b9aca01, 0xa0000}};
+  s21_decimal result = S21_DECIMAL_NULL;
+  int is_equal = -999;
+  int is_error = -99;
+
+  is_error = s21_add(x, y, &result);
+
+  is_equal = _tests_add_check_bits(result, expect);
+  ck_assert_int_eq(is_equal, S21_TRUE);
+  ck_assert_int_eq(is_error, 0);
+}
+
+START_TEST(possible_verter_test_3) {
+  s21_decimal x = {.bits = {24, 1, 1, -2147418112}};
+  s21_decimal y = {.bits = {1, 15, 1, 655360}};
+  s21_decimal expect = {{0x9682efff, 0x3b9ac9f6, 0x3b9ac9ff, 0x800a0000}};
+  s21_decimal result = S21_DECIMAL_NULL;
+  int is_equal = -999;
+  int is_error = -99;
+
+  is_error = s21_add(x, y, &result);
+
+  is_equal = _tests_add_check_bits(result, expect);
+  ck_assert_int_eq(is_equal, S21_TRUE);
+  ck_assert_int_eq(is_error, 0);
+}
+
+START_TEST(possible_verter_test_4) {
+  s21_decimal x = {.bits = {1, 1, 1, 655360}};
+  s21_decimal y = {.bits = {1, 1, 1, -2147418112}};
+  s21_decimal expect = {{0x3b9ac9ff, 0x3b9ac9ff, 0x3b9ac9ff, 0x800a0000}};
+  s21_decimal result = S21_DECIMAL_NULL;
+  int is_equal = -999;
+  int is_error = -99;
+
+  is_error = s21_add(x, y, &result);
+
+  is_equal = _tests_add_check_bits(result, expect);
+  ck_assert_int_eq(is_equal, S21_TRUE);
+  ck_assert_int_eq(is_error, 0);
+}
+
 TCase *tcase_s21_add(void) {
   TCase *tc;
 
@@ -243,6 +303,11 @@ TCase *tcase_s21_add(void) {
   tcase_add_test(tc, negative_overflow_not_happen);
   tcase_add_test(tc, adding_negative_and_positive_result_positive_null);
   tcase_add_test(tc, adding_positive_and_negative_result_positive_null);
+
+  tcase_add_test(tc, possible_verter_test_1);
+  tcase_add_test(tc, possible_verter_test_2);
+  tcase_add_test(tc, possible_verter_test_3);
+  tcase_add_test(tc, possible_verter_test_4);
 
   return tc;
 }

--- a/src/tests/tests_s21_sub.c
+++ b/src/tests/tests_s21_sub.c
@@ -1,0 +1,73 @@
+#include <check.h>
+
+#include "../s21_decimal.h"
+
+int _tests_sub_check_bits(s21_decimal first, s21_decimal second) {
+  int is_equal = S21_TRUE;
+
+  for (int i = LOW; i <= SCALE; i++) {
+    if (first.bits[i] != second.bits[i]) is_equal = S21_FALSE;
+  }
+
+  return is_equal;
+}
+
+START_TEST(possible_verter_test_1) {
+  s21_decimal x = {.bits = {1, 1, 1, 65536}};
+  s21_decimal y = {.bits = {1, 1, 1, -2147418112}};
+  s21_decimal expect = {.bits = {0x2, 0x2, 0x2, 0x10000}};
+  s21_decimal result = S21_DECIMAL_NULL;
+  int is_equal = -999;
+  int is_error = -99;
+
+  is_error = s21_sub(x, y, &result);
+
+  is_equal = _tests_sub_check_bits(result, expect);
+  ck_assert_int_eq(is_equal, S21_TRUE);
+  ck_assert_int_eq(is_error, 0);
+}
+END_TEST
+
+START_TEST(possible_verter_test_2) {
+  s21_decimal x = {.bits = {1, 1, 1, -2147418112}};
+  s21_decimal y = {.bits = {1, 1, 1, -2147418112}};
+  s21_decimal expect = {.bits = {0, 0, 0, 0x80010000}};
+  s21_decimal result = S21_DECIMAL_NULL;
+  int is_equal = -999;
+  int is_error = -99;
+
+  is_error = s21_sub(x, y, &result);
+
+  is_equal = _tests_sub_check_bits(result, expect);
+  ck_assert_int_eq(is_equal, S21_TRUE);
+  ck_assert_int_eq(is_error, 0);
+}
+END_TEST
+
+START_TEST(possible_verter_test_3) {
+  s21_decimal x = {.bits = {1, 1, 1, -2147418112}};
+  s21_decimal y = {.bits = {1, 1, 1, 65536}};
+  s21_decimal expect = {.bits = {0x2, 0x2, 0x2, 0x80010000}};
+  s21_decimal result = S21_DECIMAL_NULL;
+  int is_equal = -999;
+  int is_error = -99;
+
+  is_error = s21_sub(x, y, &result);
+
+  is_equal = _tests_sub_check_bits(result, expect);
+  ck_assert_int_eq(is_equal, S21_TRUE);
+  ck_assert_int_eq(is_error, 0);
+}
+END_TEST
+
+TCase *tcase_s21_sub(void) {
+  TCase *tc;
+
+  tc = tcase_create("Tests for `s21_sub`");
+
+  tcase_add_test(tc, possible_verter_test_1);
+  tcase_add_test(tc, possible_verter_test_2);
+  tcase_add_test(tc, possible_verter_test_3);
+
+  return tc;
+}


### PR DESCRIPTION
s21_sub - функция вычитания + минимальные тесты для неё.

Подправил фукнцию конвертации из `big_decimal` в `decimal` — мог быть бесконечный цикл при попытке убрать трайлинг нули.